### PR TITLE
Use DevIcon highlight groups based on file type

### DIFF
--- a/lua/winbar/winbar.lua
+++ b/lua/winbar/winbar.lua
@@ -28,7 +28,6 @@ local winbar_file = function()
     local file_type = vim.fn.expand('%:e')
     local value = ''
     local file_icon = ''
-    local file_icon_color = ''
 
     file_path = file_path:gsub('^%.', '')
     file_path = file_path:gsub('^%/', '')
@@ -42,15 +41,14 @@ local winbar_file = function()
         end
 
         if status_web_devicons_ok then
-            file_icon, file_icon_color = web_devicons.get_icon_color(filename, file_type, { default = default })
-            hl_winbar_file_icon = "DevIcon" .. file_type:sub(1,1):upper()..file_type:sub(2)
+            file_icon = web_devicons.get_icon(filename, file_type, { default = default })
+            hl_winbar_file_icon = "DevIcon" .. file_type
         end
 
         if not file_icon then
             file_icon = opts.icons.file_icon_default
         end
 
-        vim.api.nvim_set_hl(0, hl_winbar_file_icon, { fg = file_icon_color })
         file_icon = '%#' .. hl_winbar_file_icon .. '#' .. file_icon .. ' %*'
 
         value = ' '

--- a/lua/winbar/winbar.lua
+++ b/lua/winbar/winbar.lua
@@ -43,6 +43,7 @@ local winbar_file = function()
 
         if status_web_devicons_ok then
             file_icon, file_icon_color = web_devicons.get_icon_color(filename, file_type, { default = default })
+            hl_winbar_file_icon = "DevIcon" .. file_type:sub(1,1):upper()..file_type:sub(2)
         end
 
         if not file_icon then


### PR DESCRIPTION
The current usage of a global highlight group for file icons results in wrong icon colors when working with splits with different file types. The icon color, no matter the file type, will always be the color of the icon highlight set in the active split.

_E.g. 1, lua | md open -> blue md icon if lua focus_
![wb2](https://user-images.githubusercontent.com/34311583/178125618-ebde55af-1992-4c7d-9a56-2ce776e6a7a4.png)

_E.g. 2, lua | md open -> white lua if md focus_
![wb1](https://user-images.githubusercontent.com/34311583/178125621-c597b240-eb0f-4cef-a3e8-6a348bfc2570.png)

This PR solves this by using the DevIcons highlight groups based on the file type if there is a file icon.