### PR TITLE
fix: delayed loading of the nvim-gps module

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ require('winbar').setup({
 
     icons = {
         file_icon_default = '',
-        seperator = '>',
+        separator = '>',
         editor_state = '●',
         lock_icon = '',
     },

--- a/lua/winbar/config.lua
+++ b/lua/winbar/config.lua
@@ -14,7 +14,7 @@ M.defaults = {
 
     icons = {
         file_icon_default = '',
-        seperator = '>',
+        separator = '>',
         editor_state = '●',
         lock_icon = '',
     },

--- a/lua/winbar/winbar.lua
+++ b/lua/winbar/winbar.lua
@@ -59,7 +59,7 @@ local winbar_file = function()
             end)
 
             for i = 1, #file_path_list do
-                value = value .. '%#' .. hl_winbar_path .. '#' .. file_path_list[i] .. ' ' .. opts.icons.seperator .. ' %*'
+                value = value .. '%#' .. hl_winbar_path .. '#' .. file_path_list[i] .. ' ' .. opts.icons.separator .. ' %*'
             end
         end
         value = value .. file_icon
@@ -76,7 +76,7 @@ local winbar_gps = function()
     local value = ''
 
     if status_ok and gps.is_available() and gps_location ~= 'error' and not f.isempty(gps_location) then
-        value = '%#' .. hl_winbar_symbols .. '# ' .. opts.icons.seperator .. ' %*'
+        value = '%#' .. hl_winbar_symbols .. '# ' .. opts.icons.separator .. ' %*'
         value = value .. '%#' .. hl_winbar_symbols .. '#'  .. gps_location .. '%*'
     end
 

--- a/lua/winbar/winbar.lua
+++ b/lua/winbar/winbar.lua
@@ -70,8 +70,8 @@ local winbar_file = function()
 
 end
 
-local _, gps = pcall(require, 'nvim-gps')
 local winbar_gps = function()
+    local _, gps = pcall(require, 'nvim-gps')
     local status_ok, gps_location = pcall(gps.get_location, {})
     local value = ''
 


### PR DESCRIPTION
What
====

Delays the loading of nvim-gps until required

Why
====

nvim-gps is being loaded when winbar.nvim is loaded, this causes a issue if nvim-gps is loaded after. 
This is a workaround that delays the  loading of nvim-gps

Addresses the issue reported here: https://github.com/fgheng/winbar.nvim/issues/14