### PR TITLE
Add right_align option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ require('winbar').setup({
 
     show_file_path = true,
     show_symbols = true,
+    right_align = false,
 
     colors = {
         path = '', -- You can customize colors like #c946fd

--- a/lua/winbar/config.lua
+++ b/lua/winbar/config.lua
@@ -5,6 +5,7 @@ M.defaults = {
 
     show_file_path = true,
     show_symbols = true,
+    right_align = false,
 
     colors = {
         path = '',

--- a/lua/winbar/winbar.lua
+++ b/lua/winbar/winbar.lua
@@ -119,6 +119,10 @@ M.show_winbar = function()
 
     local value = winbar_file()
 
+    if opts.right_align then
+        value = "%=" .. value
+    end
+
     if opts.show_symbols then
         if not f.isempty(value) then
             local gps_value = winbar_gps()


### PR DESCRIPTION
As the title already says - this PR adds the option to set right_align=true (default: false) to align the winbar at the right side